### PR TITLE
Potential fix for code scanning alert no. 3: Disabled TLS certificate check

### DIFF
--- a/extensions/xk6-output-opensearch/internal/opeoutput.go
+++ b/extensions/xk6-output-opensearch/internal/opeoutput.go
@@ -69,8 +69,9 @@ func New(params output.Params) (output.Output, error) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify},
 	}
 
+	// Ensure TLS certificate verification is enabled
 	osConfig.Client.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{},
 	}
 	osConfig.Client.EnableRetryOnTimeout=true;
 	osConfig.Client.MaxRetries=10;

--- a/extensions/xk6-output-opensearch/internal/opeoutput.go
+++ b/extensions/xk6-output-opensearch/internal/opeoutput.go
@@ -64,15 +64,11 @@ func New(params output.Params) (output.Output, error) {
 	if config.Password.Valid {
 		osConfig.Client.Password = config.Password.String
 	}
-
+    // Ensure TLS certificate verification can be enabled
 	osConfig.Client.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify},
 	}
 
-	// Ensure TLS certificate verification is enabled
-	osConfig.Client.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{},
-	}
 	osConfig.Client.EnableRetryOnTimeout=true;
 	osConfig.Client.MaxRetries=10;
 	osConfig.Client.RetryOnStatus=[]int{502,503, 504,403};


### PR DESCRIPTION
Potential fix for [https://github.com/UserOfficeProject/user-office-proposal-performance-tests/security/code-scanning/3](https://github.com/UserOfficeProject/user-office-proposal-performance-tests/security/code-scanning/3)

To fix the problem, we need to ensure that `InsecureSkipVerify` is not set to `true` in production code. Instead, we should configure the application to use valid certificates that can be verified. This involves removing the line that sets `InsecureSkipVerify` to `true` and ensuring that the configuration uses proper certificate verification.

1. Remove the line that sets `InsecureSkipVerify` to `true`.
2. Ensure that the configuration uses valid certificates for TLS connections.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
