### PR TITLE
feat: add tracing to tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "prettier": "3.5.3",
-        "typescript": "^5.3.3",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.19.1",
         "webpack": "^5.94.0",
         "webpack-cli": "^5.1.4",
@@ -11661,10 +11661,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "3.5.3",
-    "typescript": "^5.3.3",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.19.1",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
@@ -68,9 +68,9 @@
   "dependencies": {
     "@inquirer/prompts": "^7.3.1",
     "@kubernetes/client-node": "^1.0.0",
+    "concurrently": "^9.1.2",
     "date-fns": "^4.1.0",
     "js-yaml": "^4.1.0",
-    "ora": "^8.2.0",
-    "concurrently": "^9.1.2"
+    "ora": "^8.2.0"
   }
 }

--- a/src/support/graphql.ts
+++ b/src/support/graphql.ts
@@ -1,4 +1,5 @@
 import http, { RequestBody } from 'k6/http';
+import tempo from 'https://jslib.k6.io/http-instrumentation-tempo/1.0.1/index.js';
 
 import {
   AsyncClientApi,
@@ -24,6 +25,10 @@ export function getClientApi(
   graphqlUrl: string,
   bearerToken?: string
 ): ClientApi {
+  tempo.instrumentHTTP({
+    propagator: 'w3c',
+    sampling: 1,
+  });
   if (bearerToken) {
     return function (body: string, userToken?: string) {
       return http.post(graphqlUrl, body, {
@@ -64,6 +69,10 @@ export function getAsyncClientApi(
   graphqlUrl: string,
   bearerToken?: string
 ): AsyncClientApi {
+  tempo.instrumentHTTP({
+    propagator: 'w3c',
+    sampling: 1,
+  });
   if (bearerToken) {
     return function (
       method: string,

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -1,5 +1,4 @@
 import { FsFile, UserLogin } from './sharedType';
-import { crypto } from 'k6/experimental/webcrypto';
 
 export function randomUUIDv4(): string {
   //This is an experimental module.

--- a/src/utils/k6-http-instrumentation-tempo.d.ts
+++ b/src/utils/k6-http-instrumentation-tempo.d.ts
@@ -1,0 +1,33 @@
+// k6-http-instrumentation-tempo.d.ts for version 1.0.1
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'https://jslib.k6.io/http-instrumentation-tempo/1.0.1/index.js' {
+  interface InstrumentationOptions {
+    sampling?: number;
+    propagator: "w3c" | "jaeger";
+  }
+  class Client {
+    constructor(
+      opts: InstrumentationOptions,
+      originalRequest?: (method: string, url: string, ...args: any[]) => any,
+      originalAsyncRequest?: (method: string, url: string, ...args: any[]) => Promise<any>
+    );
+    configure(opts: InstrumentationOptions): void;
+    request(method: string, url: string, ...args: any[]): any;
+    async asyncRequest(method: string, url: string, ...args: any[]): Promise<any>;
+    del(url: string, ...args: any[]): any;
+    get(url: string, ...args: any[]): any;
+    head(url: string, ...args: any[]): any;
+    options(url: string, ...args: any[]): any;
+    patch(url: string, ...args: any[]): any;
+    post(url: string, ...args: any[]): any;
+    put(url: string, ...args: any[]): any;
+  }
+  export function instrumentHTTP(opts: InstrumentationOptions): void;
+  const exp: {
+    Client: typeof Client;
+    instrumentHTTP: typeof instrumentHTTP;
+  };
+
+  export { Client, instrumentHTTP };
+  export default exp;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,12 @@
     "moduleResolution": "node",
     "module": "commonjs",
     "types": ["k6"],
+    "baseUrl": ".",
+    "paths": {
+      "https://jslib.k6.io/http-instrumentation-tempo/1.0.1/index.js": [
+        "./src/utils/k6-http-instrumentation-tempo.d.ts"
+      ]
+    },
     "noEmit": true,
     "allowJs": true,
     "removeComments": false,


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
Closes: https://github.com/UserOfficeProject/user-office-proposal-performance-tests/issues/131
This pull request enhances the observability of our performance tests by introducing distributed tracing for HTTP requests originating from K6 client and also makes some small upgrade to typescript and webcrypto which is now part of the K6 core. This means that each HTTP request initiated by a K6 script will now generate trace spans, allowing us to visualize the flow and latency of these requests across our systems.To specifically filter traces originating from K6 clients, users can apply the following filter in Grafana `http.user_agent="Grafana k6/1.0.0"` or what ever future version of k6.

There are also some limitations which needs future work mainly incomplete traces: This could be due to several factors, including:
1. Downstream trace collectors encountering issues processing partially complete traces.
2. Context (e.g., trace IDs, span IDs) not being correctly propagated from the K6 client into the subsequent services.

![image](https://github.com/user-attachments/assets/2bb435f6-d01c-4254-90a6-9fda654a2698)
